### PR TITLE
Making code device agnostic

### DIFF
--- a/robustbench/data.py
+++ b/robustbench/data.py
@@ -23,7 +23,7 @@ def load_cifar10(n_examples, data_dir='./data'):
     x_test = torch.cat(x_test)[:n_examples]
     y_test = torch.cat(y_test)[:n_examples]
 
-    return x_test.cuda(), y_test.cuda()
+    return x_test, y_test
 
 
 def load_cifar10c(n_examples, severity=5, data_dir='./data', shuffle=False,
@@ -82,7 +82,7 @@ def load_cifar10c(n_examples, severity=5, data_dir='./data', shuffle=False,
     x_test = torch.tensor(x_test)[:n_examples]  # to make sure that we get exactly n_examples but not a few samples more
     y_test = torch.tensor(y_test)[:n_examples]
 
-    return x_test.cuda(), y_test.cuda()
+    return x_test, y_test
 
 
 if __name__ == '__main__':

--- a/robustbench/eval.py
+++ b/robustbench/eval.py
@@ -1,4 +1,7 @@
 import argparse
+
+import torch
+
 from robustbench.utils import load_model, clean_accuracy
 from robustbench.data import load_cifar10
 
@@ -18,9 +21,11 @@ def parse_args():
 
 if __name__ == '__main__':
     args = parse_args()
+    device = torch.device('cuda:0')
 
     x_test, y_test = load_cifar10(args.n_ex, args.data_dir)
-    model = load_model(args.model_name, args.model_dir, args.norm).cuda().eval()
+    x_test, y_test = x_test.to(device), y_test.to(device)
+    model = load_model(args.model_name, args.model_dir, args.norm).to(device).eval()
 
     acc = clean_accuracy(model, x_test, y_test, batch_size=args.batch_size)
     print('Clean accuracy: {:.2%}'.format(acc))

--- a/robustbench/eval.py
+++ b/robustbench/eval.py
@@ -15,19 +15,20 @@ def parse_args():
     parser.add_argument('--batch_size', type=int, default=500, help='batch size for evaluation')
     parser.add_argument('--data_dir', type=str, default='./data', help='where to store downloaded datasets')
     parser.add_argument('--model_dir', type=str, default='./models', help='where to store downloaded models')
+    parser.add_argument('--device', type=str, default='cuda:0', help='device to use for computations')
     args = parser.parse_args()
     return args
 
 
 if __name__ == '__main__':
     args = parse_args()
-    device = torch.device('cuda:0')
+    device = torch.device(args.device)
 
     x_test, y_test = load_cifar10(args.n_ex, args.data_dir)
     x_test, y_test = x_test.to(device), y_test.to(device)
     model = load_model(args.model_name, args.model_dir, args.norm).to(device).eval()
 
-    acc = clean_accuracy(model, x_test, y_test, batch_size=args.batch_size)
+    acc = clean_accuracy(model, x_test, y_test, batch_size=args.batch_size, device=device)
     print('Clean accuracy: {:.2%}'.format(acc))
 
     adversary = AutoAttack(model, norm=args.norm, eps=args.eps, version='standard')

--- a/robustbench/model_zoo/models.py
+++ b/robustbench/model_zoo/models.py
@@ -34,13 +34,10 @@ class Hendrycks2019UsingNet(WideResNet):
 class Rice2020OverfittingNet(WideResNet):
     def __init__(self, depth=34, widen_factor=20):
         super(Rice2020OverfittingNet, self).__init__(depth=depth, widen_factor=widen_factor, sub_block1=False)
-        self.mu = torch.Tensor([0.4914, 0.4822, 0.4465]).float().view(3, 1, 1).cuda()
-        self.sigma = torch.Tensor([0.2471, 0.2435, 0.2616]).float().view(3, 1, 1).cuda()
+        self.register_buffer('mu', torch.tensor([0.4914, 0.4822, 0.4465]).view(1, 3, 1, 1))
+        self.register_buffer('sigma', torch.tensor([0.2471, 0.2435, 0.2616]).view(1, 3, 1, 1))
 
     def forward(self, x):
-        if x.device != self.mu.device:
-            self.mu = self.mu.to(x.device)
-            self.sigma = self.sigma.to(x.device)
         x = (x - self.mu) / self.sigma
         return super(Rice2020OverfittingNet, self).forward(x)
 
@@ -53,13 +50,10 @@ class Zhang2019TheoreticallyNet(WideResNet):
 class Engstrom2019RobustnessNet(ResNet):
     def __init__(self):
         super(Engstrom2019RobustnessNet, self).__init__(Bottleneck, [3, 4, 6, 3])
-        self.mu = torch.Tensor([0.4914, 0.4822, 0.4465]).float().view(3, 1, 1).cuda()
-        self.sigma = torch.Tensor([0.2023, 0.1994, 0.2010]).float().view(3, 1, 1).cuda()
+        self.register_buffer('mu', torch.tensor([0.4914, 0.4822, 0.4465]).view(1, 3, 1, 1))
+        self.register_buffer('sigma', torch.tensor([0.2023, 0.1994, 0.2010]).view(1, 3, 1, 1))
 
     def forward(self, x):
-        if x.device != self.mu.device:
-            self.mu = self.mu.to(x.device)
-            self.sigma = self.sigma.to(x.device)
         x = (x - self.mu) / self.sigma
         return super(Engstrom2019RobustnessNet, self).forward(x)
 
@@ -73,13 +67,10 @@ class Chen2020AdversarialNet(torch.nn.Module):
 
         self.models = [self.branch1, self.branch2, self.branch3]
 
-        self.mu = torch.Tensor([0.485, 0.456, 0.406]).float().view(1, 3, 1, 1).cuda()
-        self.sigma = torch.Tensor([0.229, 0.224, 0.225]).float().view(1, 3, 1, 1).cuda()
+        self.register_buffer('mu', torch.tensor([0.485, 0.456, 0.406]).view(1, 3, 1, 1))
+        self.register_buffer('sigma', torch.tensor([0.229, 0.224, 0.225]).view(1, 3, 1, 1))
 
     def forward(self, x):
-        if x.device != self.mu.device:
-            self.mu = self.mu.to(x.device)
-            self.sigma = self.sigma.to(x.device)
         out = (x - self.mu) / self.sigma
 
         out1 = self.branch1(out)
@@ -102,13 +93,10 @@ class Pang2020BoostingNet(WideResNet):
     def __init__(self, depth=34, widen_factor=20):
         super(Pang2020BoostingNet, self).__init__(depth=depth, widen_factor=widen_factor,
             sub_block1=True, bias_last=False)
-        self.mu = torch.Tensor([0.4914, 0.4822, 0.4465]).float().view(3, 1, 1).cuda()
-        self.sigma = torch.Tensor([0.2471, 0.2435, 0.2616]).float().view(3, 1, 1).cuda()
+        self.register_buffer('mu', torch.tensor([0.4914, 0.4822, 0.4465]).view(1, 3, 1, 1))
+        self.register_buffer('sigma', torch.tensor([0.2471, 0.2435, 0.2616]).view(1, 3, 1, 1))
 
     def forward(self, x):
-        if x.device != self.mu.device:
-            self.mu = self.mu.to(x.device)
-            self.sigma = self.sigma.to(x.device)
         x = (x - self.mu) / self.sigma
         out = self.conv1(x)
         out = self.block1(out)
@@ -127,13 +115,10 @@ class Pang2020BoostingNet(WideResNet):
 class Wong2020FastNet(PreActResNet):
     def __init__(self):
         super(Wong2020FastNet, self).__init__(PreActBlock, [2, 2, 2, 2])
-        self.mu = torch.Tensor([0.4914, 0.4822, 0.4465]).float().view(3, 1, 1).cuda()
-        self.sigma = torch.Tensor([0.2471, 0.2435, 0.2616]).float().view(3, 1, 1).cuda()
+        self.register_buffer('mu', torch.tensor([0.4914, 0.4822, 0.4465]).view(1, 3, 1, 1))
+        self.register_buffer('sigma', torch.tensor([0.2471, 0.2435, 0.2616]).view(1, 3, 1, 1))
 
     def forward(self, x):
-        if x.device != self.mu.device:
-            self.mu = self.mu.to(x.device)
-            self.sigma = self.sigma.to(x.device)
         x = (x - self.mu) / self.sigma
         return super(Wong2020FastNet, self).forward(x)
 
@@ -171,13 +156,10 @@ class Zhang2020AttacksNet(WideResNet):
 class Augustin2020AdversarialNet(ResNet):
     def __init__(self):
         super(Augustin2020AdversarialNet, self).__init__(Bottleneck, [3, 4, 6, 3])
-        self.mu = torch.Tensor([0.4913997551666284, 0.48215855929893703, 0.4465309133731618]).float().view(3, 1, 1).cuda()
-        self.sigma = torch.Tensor([0.24703225141799082, 0.24348516474564, 0.26158783926049628]).float().view(3, 1, 1).cuda()
+        self.register_buffer('mu', torch.tensor([0.4913997551666284, 0.48215855929893703, 0.4465309133731618]).view(1, 3, 1, 1))
+        self.register_buffer('sigma', torch.tensor([0.24703225141799082, 0.24348516474564, 0.26158783926049628]).view(1, 3, 1, 1))
 
     def forward(self, x):
-        if x.device != self.mu.device:
-            self.mu = self.mu.to(x.device)
-            self.sigma = self.sigma.to(x.device)
         x = (x - self.mu) / self.sigma
         return super(Augustin2020AdversarialNet, self).forward(x)
 
@@ -185,13 +167,10 @@ class Augustin2020AdversarialNet(ResNet):
 class Rice2020OverfittingNetL2(PreActResNet):
     def __init__(self):
         super(Rice2020OverfittingNetL2, self).__init__(PreActBlockV2, [2, 2, 2, 2], bn_before_fc=True)
-        self.mu = torch.Tensor([0.4914, 0.4822, 0.4465]).float().view(3, 1, 1).cuda()
-        self.sigma = torch.Tensor([0.2471, 0.2435, 0.2616]).float().view(3, 1, 1).cuda()
+        self.register_buffer('mu', torch.tensor([0.4914, 0.4822, 0.4465]).view(1, 3, 1, 1))
+        self.register_buffer('sigma', torch.tensor([0.2471, 0.2435, 0.2616]).view(1, 3, 1, 1))
 
     def forward(self, x):
-        if x.device != self.mu.device:
-            self.mu = self.mu.to(x.device)
-            self.sigma = self.sigma.to(x.device)
         x = (x - self.mu) / self.sigma
         return super(Rice2020OverfittingNetL2, self).forward(x)
 
@@ -199,13 +178,10 @@ class Rice2020OverfittingNetL2(PreActResNet):
 class Rony2019DecouplingNet(WideResNet):
     def __init__(self, depth=28, widen_factor=10):
         super(Rony2019DecouplingNet, self).__init__(depth=depth, widen_factor=widen_factor, sub_block1=False)
-        self.mu = torch.tensor([0.491, 0.482, 0.447]).view(3, 1, 1).cuda()
-        self.sigma = torch.tensor([0.247, 0.243, 0.262]).view(3, 1, 1).cuda()
+        self.register_buffer('mu', torch.tensor([0.491, 0.482, 0.447]).view(1, 3, 1, 1))
+        self.register_buffer('sigma', torch.tensor([0.247, 0.243, 0.262]).view(1, 3, 1, 1))
 
     def forward(self, x):
-        if x.device != self.mu.device:
-            self.mu = self.mu.to(x.device)
-            self.sigma = self.sigma.to(x.device)
         x = (x - self.mu) / self.sigma
         return super(Rony2019DecouplingNet, self).forward(x)
 

--- a/robustbench/utils.py
+++ b/robustbench/utils.py
@@ -91,13 +91,15 @@ def load_model(model_name, model_dir='./models', norm='Linf'):
         return model.eval()
 
 
-def clean_accuracy(model, x, y, batch_size=100):
+def clean_accuracy(model, x, y, batch_size=100, device=None):
+    if device is None:
+        device = x.device
     acc = 0.
     n_batches = math.ceil(x.shape[0] / batch_size)
     with torch.no_grad():
         for counter in range(n_batches):
-            x_curr = x[counter * batch_size:(counter + 1) * batch_size]
-            y_curr = y[counter * batch_size:(counter + 1) * batch_size]
+            x_curr = x[counter * batch_size:(counter + 1) * batch_size].to(device)
+            y_curr = y[counter * batch_size:(counter + 1) * batch_size].to(device)
 
             output = model(x_curr)
             acc += (output.max(1)[1] == y_curr).float().sum()

--- a/tests/config.py
+++ b/tests/config.py
@@ -2,7 +2,8 @@ def get_test_config():
     config = {
         'batch_size': 500,
         'data_dir': './data',
-        'model_dir': './models'
+        'model_dir': './models',
+        'device': 'cuda:0'
     }
     return config
 

--- a/tests/test_clean_acc.py
+++ b/tests/test_clean_acc.py
@@ -1,5 +1,8 @@
 import unittest
 import json
+
+import torch
+
 from tests.config import get_test_config
 from robustbench.utils import load_model, clean_accuracy
 from robustbench.data import load_cifar10
@@ -10,8 +13,10 @@ from tests.utils_testing import slow
 class CleanAccTester(unittest.TestCase):
     def test_clean_acc_jsons_fast(self):
         config = get_test_config()
+        device = torch.device(config['device'])
         n_ex = 200
         x_test, y_test = load_cifar10(n_ex, config['data_dir'])
+        x_test, y_test = x_test.to(device), y_test.to(device)
 
         for norm in model_dicts.keys():
             print('Test models robust wrt {}'.format(norm))
@@ -20,7 +25,7 @@ class CleanAccTester(unittest.TestCase):
 
             n_tests_passed = 0
             for model_name in models:
-                model = load_model(model_name, config['model_dir'], norm).cuda().eval()
+                model = load_model(model_name, config['model_dir'], norm).to(device)
 
                 acc = clean_accuracy(model, x_test, y_test, batch_size=config['batch_size'])
 
@@ -34,8 +39,10 @@ class CleanAccTester(unittest.TestCase):
     @slow
     def test_clean_acc_jsons_exact(self):
         config = get_test_config()
+        device = torch.device(config['device'])
         n_ex = 10000
         x_test, y_test = load_cifar10(n_ex, config['data_dir'])
+        x_test, y_test = x_test.to(device), y_test.to(device)
 
         for norm in model_dicts.keys():
             print('Test models robust wrt {}'.format(norm))
@@ -44,7 +51,7 @@ class CleanAccTester(unittest.TestCase):
 
             n_tests_passed = 0
             for model_name in models:
-                model = load_model(model_name, config['model_dir'], norm).cuda().eval()
+                model = load_model(model_name, config['model_dir'], norm).to(device)
 
                 acc = clean_accuracy(model, x_test, y_test, batch_size=config['batch_size'])
                 with open('./model_info/{}/{}.json'.format(norm, model_name), 'r') as model_info:

--- a/tests/test_clean_acc.py
+++ b/tests/test_clean_acc.py
@@ -16,7 +16,6 @@ class CleanAccTester(unittest.TestCase):
         device = torch.device(config['device'])
         n_ex = 200
         x_test, y_test = load_cifar10(n_ex, config['data_dir'])
-        x_test, y_test = x_test.to(device), y_test.to(device)
 
         for norm in model_dicts.keys():
             print('Test models robust wrt {}'.format(norm))
@@ -27,7 +26,7 @@ class CleanAccTester(unittest.TestCase):
             for model_name in models:
                 model = load_model(model_name, config['model_dir'], norm).to(device)
 
-                acc = clean_accuracy(model, x_test, y_test, batch_size=config['batch_size'])
+                acc = clean_accuracy(model, x_test, y_test, batch_size=config['batch_size'], device=device)
 
                 self.assertGreater(round(acc * 100., 2), 70.0)
                 success = round(acc * 100., 2) > 70.0
@@ -42,7 +41,6 @@ class CleanAccTester(unittest.TestCase):
         device = torch.device(config['device'])
         n_ex = 10000
         x_test, y_test = load_cifar10(n_ex, config['data_dir'])
-        x_test, y_test = x_test.to(device), y_test.to(device)
 
         for norm in model_dicts.keys():
             print('Test models robust wrt {}'.format(norm))
@@ -53,7 +51,7 @@ class CleanAccTester(unittest.TestCase):
             for model_name in models:
                 model = load_model(model_name, config['model_dir'], norm).to(device)
 
-                acc = clean_accuracy(model, x_test, y_test, batch_size=config['batch_size'])
+                acc = clean_accuracy(model, x_test, y_test, batch_size=config['batch_size'], device=device)
                 with open('./model_info/{}/{}.json'.format(norm, model_name), 'r') as model_info:
                     json_dict = json.load(model_info)
 


### PR DESCRIPTION
Currently, the code returns models already on cuda by calling `.cuda()` in various places.
This assumes that:
- a user should have a cuda enabled device;
- the first visible cuda device is the one to be used.

However, this is not always true in practice.

This PR fixes this by making the model creation and data loading device agnostic.

There may be a need for a discussion on how to handle the function `clean_accuracy`: with this PR, the data is put on device before calling the function. While this is fine for CIFAR10 which is small, it is not very general. One could argue that loading all samples in one Tensor (even in CPU) can also be problematic for large datasets. Still, the function `clean_accuracy` could either take a `device` argument or fetch the device using `device = next(model.parameters()).device`

Cheers