### PR TITLE
Fix missing sub_block1 for cifar100 wideresnet models by Cui et. al

### DIFF
--- a/robustbench/model_zoo/cifar100.py
+++ b/robustbench/model_zoo/cifar100.py
@@ -64,15 +64,15 @@ linf = OrderedDict([
         'gdrive_id': "1LQBdwO2b391mg7VKcP6I0HIOpC6O83gn"
     }),
     ('Cui2020Learnable_34_20_LBGAT6', {
-        'model': lambda: WideResNet(depth=34, widen_factor=20, num_classes=100),
+        'model': lambda: WideResNet(depth=34, widen_factor=20, num_classes=100, sub_block1=True),
         'gdrive_id': '1rN76st8q_32j6Uo8DI5XhcC2cwVhXBwK'
     }),
     ('Cui2020Learnable_34_10_LBGAT0', {
-        'model': lambda: WideResNet(depth=34, widen_factor=10, num_classes=100),
+        'model': lambda: WideResNet(depth=34, widen_factor=10, num_classes=100, sub_block1=True),
         'gdrive_id': '1RnWbGxN-A-ltsfOvulr68U6i2L8ohAJi'
     }),
     ('Cui2020Learnable_34_10_LBGAT6', {
-        'model': lambda: WideResNet(depth=34, widen_factor=10, num_classes=100),
+        'model': lambda: WideResNet(depth=34, widen_factor=10, num_classes=100, sub_block1=True),
         'gdrive_id': '1TfIgvW3BAkL8jL9J7AAWFSLW3SSzJ2AE'
     }),
     ('Chen2020Efficient', {


### PR DESCRIPTION
The wideresnet architecture by Cui et. al. uses sub_block1 ([compare here](https://github.com/FPNAS/LBGAT/blob/main/models/wideresnet.py)), while the wideresnet architecture used by robustbench has sub_block1 as optional and not included by default, causing an error when loading the models by Cui et. al.

Adding `sub_block1` to the model in the `cifar100.py` model_dict solves this.
