### PR TITLE
Remove all `.cuda()` calls

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 torch>=1.7.1
 torchvision>=0.8.2
 requests~=2.25.1
-numpy~=1.19.4
+numpy>=1.19.4
 Jinja2~=2.11.2
 tqdm~=4.56.1
 pandas~=1.2.0

--- a/robustbench/model_zoo/architectures/dm_wide_resnet.py
+++ b/robustbench/model_zoo/architectures/dm_wide_resnet.py
@@ -30,6 +30,7 @@ CIFAR100_STD = (0.2673, 0.2564, 0.2762)
 
 class _Swish(torch.autograd.Function):
     """Custom implementation of swish."""
+
     @staticmethod
     def forward(ctx, i):
         result = i * torch.sigmoid(i)
@@ -45,12 +46,14 @@ class _Swish(torch.autograd.Function):
 
 class Swish(nn.Module):
     """Module using custom implementation."""
+
     def forward(self, input_tensor):
         return _Swish.apply(input_tensor)
 
 
 class _Block(nn.Module):
     """WideResNet Block."""
+
     def __init__(self,
                  in_planes,
                  out_planes,
@@ -108,6 +111,7 @@ class _Block(nn.Module):
 
 class _BlockGroup(nn.Module):
     """WideResNet block group."""
+
     def __init__(self,
                  num_blocks,
                  in_planes,
@@ -130,6 +134,7 @@ class _BlockGroup(nn.Module):
 
 class DMWideResNet(nn.Module):
     """WideResNet."""
+
     def __init__(self,
                  num_classes: int = 10,
                  depth: int = 28,
@@ -140,8 +145,10 @@ class DMWideResNet(nn.Module):
                  padding: int = 0,
                  num_input_channels: int = 3):
         super().__init__()
-        self.register_buffer('mean', torch.tensor(mean).view(num_input_channels, 1, 1))
-        self.register_buffer('std', torch.tensor(std).view(num_input_channels, 1, 1))
+        self.register_buffer('mean', torch.tensor(mean).view(num_input_channels, 1, 1),
+                             persistent=False)
+        self.register_buffer('std', torch.tensor(std).view(num_input_channels, 1, 1),
+                             persistent=False)
         self.padding = padding
         num_channels = [16, 16 * width, 32 * width, 64 * width]
         assert (depth - 4) % 6 == 0
@@ -175,7 +182,7 @@ class DMWideResNet(nn.Module):
 
     def forward(self, x):
         if self.padding > 0:
-            x = F.pad(x, (self.padding, ) * 4)
+            x = F.pad(x, (self.padding,) * 4)
         out = (x - self.mean) / self.std
         out = self.init_conv(out)
         out = self.layer(out)
@@ -186,102 +193,103 @@ class DMWideResNet(nn.Module):
 
 
 class _PreActBlock(nn.Module):
-  """Pre-activation ResNet Block."""
+    """Pre-activation ResNet Block."""
 
-  def __init__(self, in_planes, out_planes, stride, activation_fn=nn.ReLU):
-    super().__init__()
-    self._stride = stride
-    self.batchnorm_0 = nn.BatchNorm2d(in_planes)
-    self.relu_0 = activation_fn()
-    # We manually pad to obtain the same effect as `SAME` (necessary when
-    # `stride` is different than 1).
-    self.conv_2d_1 = nn.Conv2d(in_planes, out_planes, kernel_size=3,
-                               stride=stride, padding=0, bias=False)
-    self.batchnorm_1 = nn.BatchNorm2d(out_planes)
-    self.relu_1 = activation_fn()
-    self.conv_2d_2 = nn.Conv2d(out_planes, out_planes, kernel_size=3, stride=1,
-                               padding=1, bias=False)
-    self.has_shortcut = stride != 1 or in_planes != out_planes
-    if self.has_shortcut:
-      self.shortcut = nn.Conv2d(in_planes, out_planes, kernel_size=3,
-                                stride=stride, padding=0, bias=False)
+    def __init__(self, in_planes, out_planes, stride, activation_fn=nn.ReLU):
+        super().__init__()
+        self._stride = stride
+        self.batchnorm_0 = nn.BatchNorm2d(in_planes)
+        self.relu_0 = activation_fn()
+        # We manually pad to obtain the same effect as `SAME` (necessary when
+        # `stride` is different than 1).
+        self.conv_2d_1 = nn.Conv2d(in_planes, out_planes, kernel_size=3,
+                                   stride=stride, padding=0, bias=False)
+        self.batchnorm_1 = nn.BatchNorm2d(out_planes)
+        self.relu_1 = activation_fn()
+        self.conv_2d_2 = nn.Conv2d(out_planes, out_planes, kernel_size=3, stride=1,
+                                   padding=1, bias=False)
+        self.has_shortcut = stride != 1 or in_planes != out_planes
+        if self.has_shortcut:
+            self.shortcut = nn.Conv2d(in_planes, out_planes, kernel_size=3,
+                                      stride=stride, padding=0, bias=False)
 
-  def _pad(self, x):
-    if self._stride == 1:
-      x = F.pad(x, (1, 1, 1, 1))
-    elif self._stride == 2:
-      x = F.pad(x, (0, 1, 0, 1))
-    else:
-      raise ValueError('Unsupported `stride`.')
-    return x
+    def _pad(self, x):
+        if self._stride == 1:
+            x = F.pad(x, (1, 1, 1, 1))
+        elif self._stride == 2:
+            x = F.pad(x, (0, 1, 0, 1))
+        else:
+            raise ValueError('Unsupported `stride`.')
+        return x
 
-  def forward(self, x):
-    out = self.relu_0(self.batchnorm_0(x))
-    shortcut = self.shortcut(self._pad(x)) if self.has_shortcut else x
-    out = self.conv_2d_1(self._pad(out))
-    out = self.conv_2d_2(self.relu_1(self.batchnorm_1(out)))
-    return out + shortcut
+    def forward(self, x):
+        out = self.relu_0(self.batchnorm_0(x))
+        shortcut = self.shortcut(self._pad(x)) if self.has_shortcut else x
+        out = self.conv_2d_1(self._pad(out))
+        out = self.conv_2d_2(self.relu_1(self.batchnorm_1(out)))
+        return out + shortcut
 
 
 class DMPreActResNet(nn.Module):
-  """Pre-activation ResNet."""
+    """Pre-activation ResNet."""
 
-  def __init__(self,
-               num_classes: int = 10,
-               depth: int = 18,
-               width: int = 0,  # Used to make the constructor consistent.
-               activation_fn: nn.Module = nn.ReLU,
-               mean: Union[Tuple[float, ...], float] = CIFAR10_MEAN,
-               std: Union[Tuple[float, ...], float] = CIFAR10_STD,
-               padding: int = 0,
-               num_input_channels: int = 3,
-               use_cuda: bool = True):
-    super().__init__()
-    if width != 0:
-      raise ValueError('Unsupported `width`.')
-    self.register_buffer('mean', torch.tensor(mean).view(num_input_channels, 1, 1))
-    self.register_buffer('std', torch.tensor(std).view(num_input_channels, 1, 1))
-    self.mean_cuda = None
-    self.std_cuda = None
-    self.padding = padding
-    self.conv_2d = nn.Conv2d(num_input_channels, 64, kernel_size=3, stride=1,
-                             padding=1, bias=False)
-    if depth == 18:
-      num_blocks = (2, 2, 2, 2)
-    elif depth == 34:
-      num_blocks = (3, 4, 6, 3)
-    else:
-      raise ValueError('Unsupported `depth`.')
-    self.layer_0 = self._make_layer(64, 64, num_blocks[0], 1, activation_fn)
-    self.layer_1 = self._make_layer(64, 128, num_blocks[1], 2, activation_fn)
-    self.layer_2 = self._make_layer(128, 256, num_blocks[2], 2, activation_fn)
-    self.layer_3 = self._make_layer(256, 512, num_blocks[3], 2, activation_fn)
-    self.batchnorm = nn.BatchNorm2d(512)
-    self.relu = activation_fn()
-    self.logits = nn.Linear(512, num_classes)
+    def __init__(self,
+                 num_classes: int = 10,
+                 depth: int = 18,
+                 width: int = 0,  # Used to make the constructor consistent.
+                 activation_fn: nn.Module = nn.ReLU,
+                 mean: Union[Tuple[float, ...], float] = CIFAR10_MEAN,
+                 std: Union[Tuple[float, ...], float] = CIFAR10_STD,
+                 padding: int = 0,
+                 num_input_channels: int = 3,
+                 use_cuda: bool = True):
+        super().__init__()
+        if width != 0:
+            raise ValueError('Unsupported `width`.')
+        self.register_buffer('mean', torch.tensor(mean).view(num_input_channels, 1, 1),
+                             persistent=False)
+        self.register_buffer('std', torch.tensor(std).view(num_input_channels, 1, 1),
+                             persistent=False)
+        self.mean_cuda = None
+        self.std_cuda = None
+        self.padding = padding
+        self.conv_2d = nn.Conv2d(num_input_channels, 64, kernel_size=3, stride=1,
+                                 padding=1, bias=False)
+        if depth == 18:
+            num_blocks = (2, 2, 2, 2)
+        elif depth == 34:
+            num_blocks = (3, 4, 6, 3)
+        else:
+            raise ValueError('Unsupported `depth`.')
+        self.layer_0 = self._make_layer(64, 64, num_blocks[0], 1, activation_fn)
+        self.layer_1 = self._make_layer(64, 128, num_blocks[1], 2, activation_fn)
+        self.layer_2 = self._make_layer(128, 256, num_blocks[2], 2, activation_fn)
+        self.layer_3 = self._make_layer(256, 512, num_blocks[3], 2, activation_fn)
+        self.batchnorm = nn.BatchNorm2d(512)
+        self.relu = activation_fn()
+        self.logits = nn.Linear(512, num_classes)
 
-  def _make_layer(self, in_planes, out_planes, num_blocks, stride,
-                  activation_fn):
-    layers = []
-    for i, stride in enumerate([stride] + [1] * (num_blocks - 1)):
-      layers.append(
-          _PreActBlock(i == 0 and in_planes or out_planes,
-                       out_planes,
-                       stride,
-                       activation_fn))
-    return nn.Sequential(*layers)
+    def _make_layer(self, in_planes, out_planes, num_blocks, stride,
+                    activation_fn):
+        layers = []
+        for i, stride in enumerate([stride] + [1] * (num_blocks - 1)):
+            layers.append(
+                _PreActBlock(i == 0 and in_planes or out_planes,
+                             out_planes,
+                             stride,
+                             activation_fn))
+        return nn.Sequential(*layers)
 
-  def forward(self, x):
-    if self.padding > 0:
-      x = F.pad(x, (self.padding,) * 4)
-    out = (x - self.mean) / self.std
-    out = self.conv_2d(out)
-    out = self.layer_0(out)
-    out = self.layer_1(out)
-    out = self.layer_2(out)
-    out = self.layer_3(out)
-    out = self.relu(self.batchnorm(out))
-    out = F.avg_pool2d(out, 4)
-    out = out.view(out.size(0), -1)
-    return self.logits(out)
-
+    def forward(self, x):
+        if self.padding > 0:
+            x = F.pad(x, (self.padding,) * 4)
+        out = (x - self.mean) / self.std
+        out = self.conv_2d(out)
+        out = self.layer_0(out)
+        out = self.layer_1(out)
+        out = self.layer_2(out)
+        out = self.layer_3(out)
+        out = self.relu(self.batchnorm(out))
+        out = F.avg_pool2d(out, 4)
+        out = out.view(out.size(0), -1)
+        return self.logits(out)

--- a/robustbench/model_zoo/architectures/dm_wide_resnet.py
+++ b/robustbench/model_zoo/architectures/dm_wide_resnet.py
@@ -140,8 +140,8 @@ class DMWideResNet(nn.Module):
                  padding: int = 0,
                  num_input_channels: int = 3):
         super().__init__()
-        self.mean = torch.tensor(mean).view(num_input_channels, 1, 1)
-        self.std = torch.tensor(std).view(num_input_channels, 1, 1)
+        self.register_buffer('mean', torch.tensor(mean).view(num_input_channels, 1, 1))
+        self.register_buffer('std', torch.tensor(std).view(num_input_channels, 1, 1))
         self.padding = padding
         num_channels = [16, 16 * width, 32 * width, 64 * width]
         assert (depth - 4) % 6 == 0
@@ -176,7 +176,7 @@ class DMWideResNet(nn.Module):
     def forward(self, x):
         if self.padding > 0:
             x = F.pad(x, (self.padding, ) * 4)
-        out = (x - self.mean.to(x.device)) / self.std.to(x.device)
+        out = (x - self.mean) / self.std
         out = self.init_conv(out)
         out = self.layer(out)
         out = self.relu(self.batchnorm(out))
@@ -239,8 +239,8 @@ class DMPreActResNet(nn.Module):
     super().__init__()
     if width != 0:
       raise ValueError('Unsupported `width`.')
-    self.mean = torch.tensor(mean).view(num_input_channels, 1, 1)
-    self.std = torch.tensor(std).view(num_input_channels, 1, 1)
+    self.register_buffer('mean', torch.tensor(mean).view(num_input_channels, 1, 1))
+    self.register_buffer('std', torch.tensor(std).view(num_input_channels, 1, 1))
     self.mean_cuda = None
     self.std_cuda = None
     self.padding = padding
@@ -274,13 +274,7 @@ class DMPreActResNet(nn.Module):
   def forward(self, x):
     if self.padding > 0:
       x = F.pad(x, (self.padding,) * 4)
-    if x.is_cuda:
-      if self.mean_cuda is None:
-        self.mean_cuda = self.mean.cuda()
-        self.std_cuda = self.std.cuda()
-      out = (x - self.mean_cuda) / self.std_cuda
-    else:
-      out = (x - self.mean) / self.std
+    out = (x - self.mean) / self.std
     out = self.conv_2d(out)
     out = self.layer_0(out)
     out = self.layer_1(out)

--- a/robustbench/model_zoo/architectures/dm_wide_resnet.py
+++ b/robustbench/model_zoo/architectures/dm_wide_resnet.py
@@ -145,6 +145,8 @@ class DMWideResNet(nn.Module):
                  padding: int = 0,
                  num_input_channels: int = 3):
         super().__init__()
+        # persistent=False to not put these tensors in the module's state_dict and not try to
+        # load it from the checkpoint
         self.register_buffer('mean', torch.tensor(mean).view(num_input_channels, 1, 1),
                              persistent=False)
         self.register_buffer('std', torch.tensor(std).view(num_input_channels, 1, 1),
@@ -246,6 +248,8 @@ class DMPreActResNet(nn.Module):
         super().__init__()
         if width != 0:
             raise ValueError('Unsupported `width`.')
+        # persistent=False to not put these tensors in the module's state_dict and not try to
+        # load it from the checkpoint
         self.register_buffer('mean', torch.tensor(mean).view(num_input_channels, 1, 1),
                              persistent=False)
         self.register_buffer('std', torch.tensor(std).view(num_input_channels, 1, 1),

--- a/robustbench/model_zoo/cifar10.py
+++ b/robustbench/model_zoo/cifar10.py
@@ -98,7 +98,7 @@ class Chen2020AdversarialNet(nn.Module):
         self.branch2 = ResNet(BottleneckChen2020AdversarialNet, [3, 4, 6, 3])
         self.branch3 = ResNet(BottleneckChen2020AdversarialNet, [3, 4, 6, 3])
 
-        self.models = [self.branch1, self.branch2, self.branch3]
+        self.models = nn.ModuleList([self.branch1, self.branch2, self.branch3])
 
         self.register_buffer(
             'mu',
@@ -316,7 +316,7 @@ class Diffenderfer2021CARD_Deck_Binary(torch.nn.Module):
     def __init__(self, num_classes=10):
         super(Diffenderfer2021CARD_Deck_Binary, self).__init__()
         self.num_cards = 6
-        self.models = []
+        self.models = nn.ModuleList()
 
         for i in range(self.num_cards):
             self.models.append(WidePreActResNet(num_classes=num_classes))

--- a/robustbench/model_zoo/cifar10.py
+++ b/robustbench/model_zoo/cifar10.py
@@ -1,8 +1,6 @@
 from collections import OrderedDict
 
 import torch
-import math
-import torch.nn.functional as F
 from torch import nn
 
 from robustbench.model_zoo.architectures.dm_wide_resnet import CIFAR10_MEAN, CIFAR10_STD, \

--- a/robustbench/model_zoo/cifar10.py
+++ b/robustbench/model_zoo/cifar10.py
@@ -277,7 +277,7 @@ class Diffenderfer2021CARD_Deck(nn.Module):
     def __init__(self, width=128):
         super(Diffenderfer2021CARD_Deck, self).__init__()
         self.num_cards = 6
-        self.models = []
+        self.models = nn.ModuleList() 
 
         for i in range(self.num_cards):
             self.models.append(LRR_ResNet(width=width))

--- a/robustbench/model_zoo/cifar100.py
+++ b/robustbench/model_zoo/cifar100.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 
 import torch
+from torch import nn
 
 from robustbench.model_zoo.architectures.dm_wide_resnet import CIFAR100_MEAN, CIFAR100_STD, \
     DMWideResNet, Swish, DMPreActResNet
@@ -124,7 +125,7 @@ class Diffenderfer2021CARD_Deck(torch.nn.Module):
     def __init__(self, width=128, num_classes=100):
         super(Diffenderfer2021CARD_Deck, self).__init__()
         self.num_cards = 6
-        self.models = []
+        self.models = nn.ModuleList()
 
         for i in range(self.num_cards):
             self.models.append(LRR_ResNet(width=width, num_classes=num_classes))
@@ -163,7 +164,7 @@ class Diffenderfer2021CARD_Deck_Binary(torch.nn.Module):
     def __init__(self, num_classes=100):
         super(Diffenderfer2021CARD_Deck_Binary, self).__init__()
         self.num_cards = 6
-        self.models = []
+        self.models = nn.ModuleList()
 
         for i in range(self.num_cards):
             self.models.append(WidePreActResNet(num_classes=num_classes))

--- a/robustbench/utils.py
+++ b/robustbench/utils.py
@@ -163,7 +163,6 @@ def load_model(model_name: str,
                                                     model_name, state_dict,
                                                     dataset_)
             model.models[i].eval()
-            model.models[i].cuda()  # Necessary for running ensembles on GPU; ideally load_model would have device argument
 
         return model.eval()
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
         'torch>=1.7.1',
         'torchvision>=0.8.2',
         'requests~=2.25.0',
-        'numpy~=1.19.4',
+        'numpy>=1.19.4',
         'Jinja2~=2.11.2',
         'tqdm~=4.56.1',
         'pandas~=1.2.0',

--- a/tests/test_clean_acc.py
+++ b/tests/test_clean_acc.py
@@ -76,7 +76,8 @@ class CleanAccTester(unittest.TestCase):
 
             with open(model_info_path) as model_info:
                 json_dict = json.load(model_info)
-
+            if abs(round(acc * 100., 2) - float(json_dict['clean_acc'])) > 0.05:
+                print(f"{model_name} accuracy test failed, {round(acc * 100., 2)} vs. {json_dict['clean_acc']}")
             self.assertLessEqual(abs(round(acc * 100., 2) - float(json_dict['clean_acc'])), 0.05)
 
             return abs(round(acc * 100., 2) - float(json_dict['clean_acc'])) <= 0.05


### PR DESCRIPTION
As correctly pointed out in #58, there are some parts in the codebase where `.cuda()` is called. This causes errors when users want to run the benchmark on machines with multiple GPUs, and the device passed as an argument to `benchmark` is not used as expected.

This PR solves this issue by using some PyTorch APIs. In particular,

- For the `DMWideResNet` and `DMPreActResNet` models I save `mean` and `std` with `register_buffer`, so that the tensors are automatically moved to the same device as the overall model.
- For the ensembles (`Chen2020AdversarialNet`, `Diffenderfer2021CARD_Deck`, `Diffenderfer2021CARD_Deck_Binary`), it is enough to save the sub-models using `nn.ModuleList`, so that the sub-models are moved to the same device as the overall model.

The overall API remains unchanged, and users can continue specifying the device to use for the benchmark by passing the `device` argument to `benchmark`.

I have run the [exact](https://github.com/RobustBench/robustbench/blob/master/tests/test_clean_acc.py#L73) clean accuracy tests on all the models, and they pass. 