### PR TITLE
Enable using ImageNet benchmarking for new models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -258,7 +258,7 @@ dmypy.json
 .prof
 
 ### vscode ###
-.vscode/*
+.vscode/
 !.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json
@@ -266,4 +266,3 @@ dmypy.json
 *.code-workspace
 
 # End of https://www.toptal.com/developers/gitignore/api/vscode,python,jupyternotebook,intellij
-n

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include data/imagenet_class_to_id_map.json
+include data/imagenet_test_image_ids.txt

--- a/README.md
+++ b/README.md
@@ -463,6 +463,19 @@ If the given `threat_model` is `corruptions`, we also save unaggregated results 
 combinations of corruption types and severities in
 [this csv file](model_info/cifar10/corruptions/unaggregated_results.csv) (for CIFAR-10).
 
+For ImageNet benchmarks, the users should specify what preprocessing should be used (e.g. resize and crop to the needed resolution). There are some preprocessings already defined in [`robustbench.data.PREPROCESSINGS`](https://github.com/RobustBench/robustbench/blob/imagenet-preprocessing/robustbench/data.py#L18), which can be used by specifying the key as the `preprocessing` parameter of `benchmark`. Otherwise, it's possible to pass an arbitrary torchvision transform (or torchvision-compatible transform), e.g.:
+
+```python
+transform = transforms.Compose([
+        transforms.Resize(256),
+        transforms.CenterCrop(224),
+        transforms.ToTensor()
+    ])
+clean_acc, robust_acc = benchmark(model, model_name=model_name, n_examples=10000, dataset=dataset,
+                                  threat_model=threat_model, eps=8/255, device=device,
+                                  to_disk=True, preprocessing=transform)
+```
+
 ##### Model definition
 
 In case you want to add a model in the Model Zoo by yourself, then you should also open a PR with

--- a/robustbench/data.py
+++ b/robustbench/data.py
@@ -1,3 +1,4 @@
+from typing import Callable, Union
 import os
 from pathlib import Path
 from typing import Callable, Dict, Optional, Sequence, Set, Tuple
@@ -9,19 +10,48 @@ import torchvision.datasets as datasets
 import torchvision.transforms as transforms
 from torch.utils.data import Dataset
 
-from robustbench.model_zoo.enums import BenchmarkDataset
+from robustbench.model_zoo import model_dicts as all_models
+from robustbench.model_zoo.enums import BenchmarkDataset, ThreatModel
 from robustbench.zenodo_download import DownloadError, zenodo_download
 from robustbench.loaders import CustomImageFolder
 
-
 PREPROCESSINGS = {
-    'Res256Crop224': transforms.Compose([transforms.Resize(256),
-                                         transforms.CenterCrop(224),
-                                         transforms.ToTensor()]),
-    'Crop288': transforms.Compose([transforms.CenterCrop(288),
-                                   transforms.ToTensor()]),
-    'none': transforms.Compose([transforms.ToTensor()]),
+    'Res256Crop224':
+    transforms.Compose([
+        transforms.Resize(256),
+        transforms.CenterCrop(224),
+        transforms.ToTensor()
+    ]),
+    'Crop288':
+    transforms.Compose([transforms.CenterCrop(288),
+                        transforms.ToTensor()]),
+    None:
+    transforms.Compose([transforms.ToTensor()]),
 }
+
+
+def get_preprocessing(
+        dataset: BenchmarkDataset, threat_model: ThreatModel,
+        model_name: Optional[str],
+        preprocessing: Optional[Union[str, Callable]]) -> Callable:
+    if isinstance(preprocessing, Callable):
+        return preprocessing
+
+    if dataset == BenchmarkDataset.imagenet:
+        if model_name is not None and model_name in all_models[dataset][
+                threat_model]:
+            prepr = all_models[dataset][threat_model][model_name][
+                'preprocessing']
+        elif preprocessing is not None:
+            prepr = preprocessing
+        else:
+            raise Exception(
+                "Preprocessing should be specified if the model is not already in the model zoo"
+            )
+    else:
+        prepr = None
+
+    return PREPROCESSINGS[prepr]
 
 
 def _load_dataset(
@@ -50,10 +80,10 @@ def _load_dataset(
 
 
 def load_cifar10(
-        n_examples: Optional[int] = None,
-        data_dir: str = './data',
-        prepr: Optional[str] = 'none') -> Tuple[torch.Tensor, torch.Tensor]:
-    transforms_test = PREPROCESSINGS[prepr]
+    n_examples: Optional[int] = None,
+    data_dir: str = './data',
+    transforms_test: Callable = PREPROCESSINGS[None]
+) -> Tuple[torch.Tensor, torch.Tensor]:
     dataset = datasets.CIFAR10(root=data_dir,
                                train=False,
                                transform=transforms_test,
@@ -62,10 +92,10 @@ def load_cifar10(
 
 
 def load_cifar100(
-        n_examples: Optional[int] = None,
-        data_dir: str = './data',
-        prepr: Optional[str] = 'none') -> Tuple[torch.Tensor, torch.Tensor]:
-    transforms_test = PREPROCESSINGS[prepr]
+    n_examples: Optional[int] = None,
+    data_dir: str = './data',
+    transforms_test: Callable = PREPROCESSINGS[None]
+) -> Tuple[torch.Tensor, torch.Tensor]:
     dataset = datasets.CIFAR100(root=data_dir,
                                 train=False,
                                 transform=transforms_test,
@@ -74,22 +104,24 @@ def load_cifar100(
 
 
 def load_imagenet(
-        n_examples: Optional[int] = 5000,
-        data_dir: str = './data',
-        prepr: str = 'Res256Crop224') -> Tuple[torch.Tensor, torch.Tensor]:
-    transforms_test = PREPROCESSINGS[prepr]
+    n_examples: Optional[int] = 5000,
+    data_dir: str = './data',
+    transforms_test: Callable = PREPROCESSINGS['Res256Crop224']
+) -> Tuple[torch.Tensor, torch.Tensor]:
     imagenet = CustomImageFolder(data_dir + '/val', transforms_test)
-    
-    test_loader = data.DataLoader(imagenet, batch_size=n_examples,
-                                  shuffle=False, num_workers=4)
+
+    test_loader = data.DataLoader(imagenet,
+                                  batch_size=n_examples,
+                                  shuffle=False,
+                                  num_workers=4)
 
     x_test, y_test, paths = next(iter(test_loader))
-    
+
     return x_test, y_test
 
 
-CleanDatasetLoader = Callable[[Optional[int], str], Tuple[torch.Tensor,
-                                                          torch.Tensor]]
+CleanDatasetLoader = Callable[[Optional[int], str, Callable],
+                              Tuple[torch.Tensor, torch.Tensor]]
 _clean_dataset_loaders: Dict[BenchmarkDataset, CleanDatasetLoader] = {
     BenchmarkDataset.cifar_10: load_cifar10,
     BenchmarkDataset.cifar_100: load_cifar100,
@@ -98,7 +130,8 @@ _clean_dataset_loaders: Dict[BenchmarkDataset, CleanDatasetLoader] = {
 
 
 def load_clean_dataset(dataset: BenchmarkDataset, n_examples: Optional[int],
-                       data_dir: str, prepr: Optional[str] = 'none') -> Tuple[torch.Tensor, torch.Tensor]:
+                       data_dir: str,
+                       prepr: Callable) -> Tuple[torch.Tensor, torch.Tensor]:
     return _clean_dataset_loaders[dataset](n_examples, data_dir, prepr)
 
 
@@ -120,25 +153,24 @@ CORRUPTIONS_DIR_NAMES: Dict[BenchmarkDataset, str] = {
 
 
 def load_cifar10c(
-    n_examples: int,
-    severity: int = 5,
-    data_dir: str = './data',
-    shuffle: bool = False,
-    corruptions: Sequence[str] = CORRUPTIONS,
-    prepr: Optional[str] = 'none'
+        n_examples: int,
+        severity: int = 5,
+        data_dir: str = './data',
+        shuffle: bool = False,
+        corruptions: Sequence[str] = CORRUPTIONS,
+        _: Callable = PREPROCESSINGS[None]
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     return load_corruptions_cifar(BenchmarkDataset.cifar_10, n_examples,
                                   severity, data_dir, corruptions, shuffle)
 
 
 def load_cifar100c(
-    n_examples: int,
-    severity: int = 5,
-    data_dir: str = './data',
-    shuffle: bool = False,
-    corruptions: Sequence[str] = CORRUPTIONS,
-    prepr: Optional[str] = 'none'
-) -> Tuple[torch.Tensor, torch.Tensor]:
+        n_examples: int,
+        severity: int = 5,
+        data_dir: str = './data',
+        shuffle: bool = False,
+        corruptions: Sequence[str] = CORRUPTIONS,
+        _: Callable = PREPROCESSINGS[None]) -> Tuple[torch.Tensor, torch.Tensor]:
     return load_corruptions_cifar(BenchmarkDataset.cifar_100, n_examples,
                                   severity, data_dir, corruptions, shuffle)
 
@@ -149,27 +181,31 @@ def load_imagenetc(
     data_dir: str = './data',
     shuffle: bool = False,
     corruptions: Sequence[str] = CORRUPTIONS,
-    prepr: str = 'Res256Crop224'
+    transforms_test: Callable = PREPROCESSINGS['Res256Crop224']
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    transforms_test = PREPROCESSINGS[prepr]
 
-    assert len(corruptions) == 1, "so far only one corruption is supported (that's how this function is called in eval.py"
+    assert len(
+        corruptions
+    ) == 1, "so far only one corruption is supported (that's how this function is called in eval.py"
     # TODO: generalize this (although this would probably require writing a function similar to `load_corruptions_cifar`
     #  or alternatively creating yet another CustomImageFolder class that fetches images from multiple corruption types
     #  at once -- perhaps this is a cleaner solution)
 
-    data_folder_path = Path(data_dir) / CORRUPTIONS_DIR_NAMES[BenchmarkDataset.imagenet] / corruptions[0] / str(severity)
+    data_folder_path = Path(data_dir) / CORRUPTIONS_DIR_NAMES[
+        BenchmarkDataset.imagenet] / corruptions[0] / str(severity)
     imagenet = CustomImageFolder(data_folder_path, transforms_test)
 
-    test_loader = data.DataLoader(imagenet, batch_size=n_examples,
-                                  shuffle=shuffle, num_workers=2)
+    test_loader = data.DataLoader(imagenet,
+                                  batch_size=n_examples,
+                                  shuffle=shuffle,
+                                  num_workers=2)
 
     x_test, y_test, paths = next(iter(test_loader))
 
     return x_test, y_test
 
 
-CorruptDatasetLoader = Callable[[int, int, str, bool, Sequence[str]],
+CorruptDatasetLoader = Callable[[int, int, str, bool, Sequence[str], Callable],
                                 Tuple[torch.Tensor, torch.Tensor]]
 CORRUPTION_DATASET_LOADERS: Dict[BenchmarkDataset, CorruptDatasetLoader] = {
     BenchmarkDataset.cifar_10: load_cifar10c,

--- a/setup.py
+++ b/setup.py
@@ -6,21 +6,18 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name="robustbench",
     version="1.0",
-    author="Francesco Croce, Maksym Andriushchenko, Vikash Sehwag, Edoardo Debenedetti",
+    author=
+    "Francesco Croce, Maksym Andriushchenko, Vikash Sehwag, Edoardo Debenedetti",
     author_email="adversarial.benchmark@gmail.com",
-    description="This package provides the data for RobustBench together with the model zoo.",
+    description=
+    "This package provides the data for RobustBench together with the model zoo.",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/RobustBench/robustbench",
     packages=setuptools.find_packages(),
     install_requires=[
-        'torch>=1.7.1',
-        'torchvision>=0.8.2',
-        'requests~=2.25.0',
-        'numpy>=1.19.4',
-        'Jinja2~=2.11.2',
-        'tqdm~=4.56.1',
-        'pandas~=1.2.0',
+        'torch>=1.7.1', 'torchvision>=0.8.2', 'requests~=2.25.0',
+        'numpy>=1.19.4', 'Jinja2~=2.11.2', 'tqdm~=4.56.1', 'pandas~=1.2.0',
         'autoattack @ git+https://github.com/fra31/auto-attack.git@6482e4d6fbeeb51ae9585c41b16d50d14576aadc#egg=autoattack'
     ],
     classifiers=[
@@ -28,4 +25,5 @@ setuptools.setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
+    include_package_data=True,
 )


### PR DESCRIPTION
Currently, it's not possible to use the `benchmark` function for ImageNet, for models that are not already in the model zoo. This is because the preprocessing to use is fetched from a dictionary that looks up in the model zoo.

Moreover, the function that filters the samples to use from ImageNet directly references the files that are used (i.e. robustbench/data/imagenet_class_to_id_map.json and robustbench/data/imagenet_test_image_ids.txt). This causes a `FileNotFoundError` when the `benchmark` function is called in a script that is run outside of the `robustbench` directory.

This PR fixes both issues, by allowing users to pass a string to specify the preprocessing to use. It also correctly packages the two files used to filter ImageNet.

~Regarding the preprocessing, a further step could be to allow passing a custom `torchvision.Transform` to give users more flexibility. Let me know what do you think about this!~ After some discussion we decided to do this. It is in my latest commit ([a316799](https://github.com/RobustBench/robustbench/pull/64/commits/a3167993eaa80a6d73ad1152802e1547b2f1d3fd)).