### PR TITLE
remove unnecessary file when loading custom ImageNet

### DIFF
--- a/robustbench/loaders.py
+++ b/robustbench/loaders.py
@@ -14,14 +14,11 @@ from PIL import Image
 import os
 import os.path
 import sys
-import json
 
 
-def make_custom_dataset(root, path_imgs, cls_dict):
+def make_custom_dataset(root, path_imgs, class_to_idx):
     with open(pkg_resources.resource_filename(__name__, path_imgs), 'r') as f:
         fnames = f.readlines()
-    with open(pkg_resources.resource_filename(__name__, cls_dict), 'r') as f:
-        class_to_idx = json.load(f)
     images = [(os.path.join(root,
                             c.split('\n')[0]), class_to_idx[c.split('/')[0]])
               for c in fnames]
@@ -70,7 +67,7 @@ class CustomDatasetFolder(VisionDataset):
         classes, class_to_idx = self._find_classes(self.root)
         samples = make_custom_dataset(
             self.root, 'data/imagenet_test_image_ids.txt',
-            'data/imagenet_class_to_id_map.json')
+            class_to_idx)
         if len(samples) == 0:
             raise (RuntimeError("Found 0 files in subfolders of: " +
                                 self.root + "\n"


### PR DESCRIPTION
As shown in the following snippet, `class_to_idx` has been obtained by function `self._find_classes(self.root)`. Therefore, `class_to_idx` can be reused by function `make_custom_dataset`. Probably, file `imagenet_class_to_id_map.json` can be removed permanently.

```python
    def __init__(self, root, loader, extensions=None, transform=None, target_transform=None, is_valid_file=None):
        super(CustomDatasetFolder, self).__init__(root)
        self.transform = transform
        self.target_transform = target_transform
        classes, class_to_idx = self._find_classes(self.root)
        samples = make_custom_dataset(self.root, 'imagenet_test_image_ids.txt',
                                      class_to_idx)
```