### PR TITLE
Fix for #105

### DIFF
--- a/robustbench/model_zoo/architectures/xcit.py
+++ b/robustbench/model_zoo/architectures/xcit.py
@@ -92,7 +92,6 @@ def debenedetti2022light_xcit_s12_imagenet_linf(pretrained=False, **kwargs):
                               pretrained=pretrained,
                               **model_kwargs)
     assert isinstance(model, xcit.XCiT)
-    model = normalize_timm_model(model)
     return model
 
 
@@ -109,7 +108,6 @@ def debenedetti2022light_xcit_m12_imagenet_linf(pretrained=False, **kwargs):
                               pretrained=pretrained,
                               **model_kwargs)
     assert isinstance(model, xcit.XCiT)
-    model = normalize_timm_model(model)
     return model
 
 
@@ -126,7 +124,6 @@ def debenedetti2022light_xcit_l12_imagenet_linf(pretrained=False, **kwargs):
                               pretrained=pretrained,
                               **model_kwargs)
     assert isinstance(model, xcit.XCiT)
-    model = normalize_timm_model(model)
     return model
 
 


### PR DESCRIPTION
This PR fixes the fact that normalization and preprocessing were incorrect for `timm` models. Now, `timm` models have a separate function that builds preprocessing by taking the default values from the model itself to make sure it uses the correct interpolation mode, and resize/crop sizes.