### PR TITLE
Modify tqdm version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ requests~=2.25.1
 numpy>=1.19.4
 Jinja2~=3.1.2
 timm~=0.6.7
-tqdm~=4.56.1
+tqdm>=4.56.1
 pandas~=1.3.5
 git+https://github.com/fra31/auto-attack.git@6482e4d6fbeeb51ae9585c41b16d50d14576aadc#egg=autoattack

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         'torch>=1.7.1', 'torchvision>=0.8.2', 'torchdiffeq', 'geotorch',
-        'requests~=2.25.0', 'numpy>=1.19.4', 'Jinja2~=3.1.2', 'tqdm~=4.56.1',
+        'requests~=2.25.0', 'numpy>=1.19.4', 'Jinja2~=3.1.2', 'tqdm>=4.56.1',
         'pandas~=1.3.5',
         'autoattack @ git+https://github.com/fra31/auto-attack.git@6482e4d6fbeeb51ae9585c41b16d50d14576aadc#egg=autoattack',
         'timm~=0.6.7'


### PR DESCRIPTION
Make it more flexible the **tqdm** version requirement. Right now it is provoking a version conflict with _tqdm_ package when installing this project along with **pytorch-lightning** 1.6.5

This is the message that I currently get:
```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts. pytorch-lightning 1.6.5 requires tqdm>=4.57.0, but you have tqdm 4.56.2 which is incompatible.
```