### PR TITLE
Fix #108

### DIFF
--- a/robustbench/model_zoo/architectures/utils_architectures.py
+++ b/robustbench/model_zoo/architectures/utils_architectures.py
@@ -34,5 +34,5 @@ M = TypeVar('M', bound=nn.Module)
 def normalize_timm_model(model: M) -> M:
     return normalize_model(
         model,
-        model.default_cfg['mean'],  # type: ignore
-        model.default_cfg['std'])  # type: ignore
+        mean=model.default_cfg['mean'],  # type: ignore
+        std=model.default_cfg['std'])  # type: ignore

--- a/robustbench/model_zoo/architectures/xcit.py
+++ b/robustbench/model_zoo/architectures/xcit.py
@@ -1,21 +1,21 @@
 from timm.models import xcit
 from timm.models.registry import register_model
 
-from robustbench.model_zoo.architectures.dm_wide_resnet import CIFAR10_MEAN, CIFAR10_STD, CIFAR100_MEAN, CIFAR100_STD
-
 from .utils_architectures import normalize_timm_model
 
+CIFAR10_MEAN = (0.4914, 0.4822, 0.4465)
+CIFAR10_STD = (0.2471, 0.2435, 0.2616)
+
+CIFAR100_MEAN = (0.5071, 0.4867, 0.4408)
+CIFAR100_STD = (0.2675, 0.2565, 0.2761)
+
 default_cfgs = {
-    'debenedetti2022light_xcit_s12_imagenet_linf':
-    xcit._cfg(
-        url=
-        "https://github.com/RobustBench/robustbench/releases/download/v1.1/debenedetti2022light-xcit-s-imagenet-linf.pth.tar"
-    ),
     'debenedetti2022light_xcit_s12_cifar10_linf':
     xcit._cfg(
         url=
         "https://github.com/RobustBench/robustbench/releases/download/v1.1/debenedetti2022light-xcit-s-cifar10-linf.pth.tar",
         input_size=(3, 32, 32),
+        num_classes=10,
         mean=CIFAR10_MEAN,
         std=CIFAR10_STD),
     'debenedetti2022light_xcit_s12_cifar100_linf':
@@ -23,13 +23,20 @@ default_cfgs = {
         url=
         "https://github.com/RobustBench/robustbench/releases/download/v1.1/debenedetti2022light-xcit-s-cifar100-linf.pth.tar",
         input_size=(3, 32, 32),
+        num_classes=100,
         mean=CIFAR100_MEAN,
         std=CIFAR100_STD),
+    'debenedetti2022light_xcit_s12_imagenet_linf':
+    xcit._cfg(
+        url=
+        "https://github.com/RobustBench/robustbench/releases/download/v1.1/debenedetti2022light-xcit-s-imagenet-linf.pth.tar"
+    ),
     'debenedetti2022light_xcit_m12_cifar10_linf':
     xcit._cfg(
         url=
         "https://github.com/RobustBench/robustbench/releases/download/v1.1/debenedetti2022light-xcit-m-cifar10-linf.pth.tar",
         input_size=(3, 32, 32),
+        num_classes=10,
         mean=CIFAR10_MEAN,
         std=CIFAR10_STD),
     'debenedetti2022light_xcit_m12_cifar100_linf':
@@ -37,6 +44,7 @@ default_cfgs = {
         url=
         "https://github.com/RobustBench/robustbench/releases/download/v1.1/debenedetti2022light-xcit-m-cifar100-linf.pth.tar",
         input_size=(3, 32, 32),
+        num_classes=100,
         mean=CIFAR100_MEAN,
         std=CIFAR100_STD),
     'debenedetti2022light_xcit_m12_imagenet_linf':
@@ -49,6 +57,7 @@ default_cfgs = {
         url=
         "https://github.com/RobustBench/robustbench/releases/download/v1.1/debenedetti2022light-xcit-l-cifar10-linf.pth.tar",
         input_size=(3, 32, 32),
+        num_classes=10,
         mean=CIFAR10_MEAN,
         std=CIFAR10_STD),
     'debenedetti2022light_xcit_l12_cifar100_linf':
@@ -56,6 +65,7 @@ default_cfgs = {
         url=
         "https://github.com/RobustBench/robustbench/releases/download/v1.1/debenedetti2022light-xcit-l-cifar100-linf.pth.tar",
         input_size=(3, 32, 32),
+        num_classes=100,
         mean=CIFAR100_MEAN,
         std=CIFAR100_STD),
     'debenedetti2022light_xcit_l12_imagenet_linf':

--- a/robustbench/utils.py
+++ b/robustbench/utils.py
@@ -119,7 +119,7 @@ def load_model(model_name: str,
     lower_model_name = model_name.lower().replace('-', '_')
     timm_model_name = f"{lower_model_name}_{dataset_.value.lower()}_{threat_model_.value.lower()}"
     
-    if timm_model_name in timm.list_models():
+    if timm.is_model(timm_model_name):
         return timm.create_model(timm_model_name,
                                  num_classes=DATASET_CLASSES[dataset_],
                                  pretrained=True,


### PR DESCRIPTION
This PR fixes #108. The issue was given by the fact that the number of classes of the non-ImageNet models was not specified, hence `timm` thought that the checkpoint had a different number of classes than the model and reset the last layer of the model.