### PR TITLE
Fix bug loading CIFAR corruptions

### DIFF
--- a/robustbench/data.py
+++ b/robustbench/data.py
@@ -320,7 +320,7 @@ def load_corruptions_cifar(
         os.makedirs(data_dir)
 
     data_dir = Path(data_dir)
-    data_root_dir = data_dir / CORRUPTIONS_DIR_NAMES[dataset]
+    data_root_dir = data_dir / CORRUPTIONS_DIR_NAMES[dataset][ThreatModel.corruptions]
 
     if not data_root_dir.exists():
         zenodo_download(*ZENODO_CORRUPTIONS_LINKS[dataset], save_dir=data_dir)


### PR DESCRIPTION
Loading CIFAR corruptions currently does not provide the type of corruptions (`ThreatModel.corruptions`), resulting in an error about unsupported operand type between a Path and dict. This resolves the issue.