### PR TITLE
Refining the package dependencies to work with the new timm version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ geotorch
 requests~=2.25.1
 numpy>=1.19.4
 Jinja2~=3.1.2
-timm~=0.6.7
+timm>=0.6.7
 tqdm>=4.56.1
 pandas~=1.3.5
 git+https://github.com/fra31/auto-attack.git@a39220048b3c9f2cca9a4d3a54604793c68eca7e#egg=autoattack

--- a/robustbench/model_zoo/architectures/xcit.py
+++ b/robustbench/model_zoo/architectures/xcit.py
@@ -76,7 +76,7 @@ default_cfgs = {
 }
 
 
-def adapt_model_patches(model: xcit.XCiT, new_patch_size: int):
+def adapt_model_patches(model: xcit.Xcit, new_patch_size: int):
     to_divide = model.patch_embed.patch_size / new_patch_size
     assert int(
         to_divide
@@ -101,7 +101,7 @@ def debenedetti2022light_xcit_s12_imagenet_linf(pretrained=False, **kwargs):
     model = xcit._create_xcit('debenedetti2022light_xcit_s12_imagenet_linf',
                               pretrained=pretrained,
                               **model_kwargs)
-    assert isinstance(model, xcit.XCiT)
+    assert isinstance(model, xcit.Xcit)
     return model
 
 
@@ -117,7 +117,7 @@ def debenedetti2022light_xcit_m12_imagenet_linf(pretrained=False, **kwargs):
     model = xcit._create_xcit('debenedetti2022light_xcit_m12_imagenet_linf',
                               pretrained=pretrained,
                               **model_kwargs)
-    assert isinstance(model, xcit.XCiT)
+    assert isinstance(model, xcit.Xcit)
     return model
 
 
@@ -133,7 +133,7 @@ def debenedetti2022light_xcit_l12_imagenet_linf(pretrained=False, **kwargs):
     model = xcit._create_xcit('debenedetti2022light_xcit_l12_imagenet_linf',
                               pretrained=pretrained,
                               **model_kwargs)
-    assert isinstance(model, xcit.XCiT)
+    assert isinstance(model, xcit.Xcit)
     return model
 
 
@@ -150,7 +150,7 @@ def debenedetti2022light_xcit_s12_cifar10_linf(pretrained=False, **kwargs):
     model = xcit._create_xcit('debenedetti2022light_xcit_s12_cifar10_linf',
                               pretrained=pretrained,
                               **model_kwargs)
-    assert isinstance(model, xcit.XCiT)
+    assert isinstance(model, xcit.Xcit)
     model = adapt_model_patches(model, 4)
     model = normalize_timm_model(model)
     return model
@@ -169,7 +169,7 @@ def debenedetti2022light_xcit_s12_cifar100_linf(pretrained=False, **kwargs):
     model = xcit._create_xcit('debenedetti2022light_xcit_s12_cifar100_linf',
                               pretrained=pretrained,
                               **model_kwargs)
-    assert isinstance(model, xcit.XCiT)
+    assert isinstance(model, xcit.Xcit)
     model = adapt_model_patches(model, 4)
     model = normalize_timm_model(model)
     return model
@@ -188,7 +188,7 @@ def debenedetti2022light_xcit_m12_cifar10_linf(pretrained=False, **kwargs):
     model = xcit._create_xcit('debenedetti2022light_xcit_m12_cifar10_linf',
                               pretrained=pretrained,
                               **model_kwargs)
-    assert isinstance(model, xcit.XCiT)
+    assert isinstance(model, xcit.Xcit)
     model = adapt_model_patches(model, 4)
     model = normalize_timm_model(model)
     return model
@@ -207,7 +207,7 @@ def debenedetti2022light_xcit_m12_cifar100_linf(pretrained=False, **kwargs):
     model = xcit._create_xcit('debenedetti2022light_xcit_m12_cifar100_linf',
                               pretrained=pretrained,
                               **model_kwargs)
-    assert isinstance(model, xcit.XCiT)
+    assert isinstance(model, xcit.Xcit)
     model = adapt_model_patches(model, 4)
     model = normalize_timm_model(model)
     return model
@@ -226,7 +226,7 @@ def debenedetti2022light_xcit_l12_cifar10_linf(pretrained=False, **kwargs):
     model = xcit._create_xcit('debenedetti2022light_xcit_l12_cifar10_linf',
                               pretrained=pretrained,
                               **model_kwargs)
-    assert isinstance(model, xcit.XCiT)
+    assert isinstance(model, xcit.Xcit)
     model = adapt_model_patches(model, 4)
     model = normalize_timm_model(model)
     return model
@@ -245,7 +245,7 @@ def debenedetti2022light_xcit_l12_cifar100_linf(pretrained=False, **kwargs):
     model = xcit._create_xcit('debenedetti2022light_xcit_l12_cifar100_linf',
                               pretrained=pretrained,
                               **model_kwargs)
-    assert isinstance(model, xcit.XCiT)
+    assert isinstance(model, xcit.Xcit)
     model = adapt_model_patches(model, 4)
     model = normalize_timm_model(model)
     return model

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
         'requests~=2.25.0', 'numpy>=1.19.4', 'Jinja2~=3.1.2', 'tqdm>=4.56.1',
         'pandas~=1.3.5',
         'autoattack @ git+https://github.com/fra31/auto-attack.git@a39220048b3c9f2cca9a4d3a54604793c68eca7e#egg=autoattack',
-        'timm~=0.6.7'
+        'timm>=0.6.7'
     ],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Previously, robustbench is only compatible with timm~=0.6.7.

In this  commit, it could be compatible with any version from 0.6.7.